### PR TITLE
Added mqtt create update and delete handlers.

### DIFF
--- a/bin/lib/cli.js
+++ b/bin/lib/cli.js
@@ -24,7 +24,7 @@ module.exports = function startCli (server) {
   
   // sba extension:
   loadCoap(program)
-  loadMqtt()
+  loadMqtt(program)
 }
 
 function getVersion () {

--- a/bin/lib/mqtt.js
+++ b/bin/lib/mqtt.js
@@ -3,18 +3,24 @@
  */
 
 var mqtt = require('mqtt')
+require('../../lib/iot/mqtt/CreateHandler')
+require('../../lib/iot/mqtt/UpdateHandler')
+require('../../lib/iot/mqtt/DeleteHandler')
 
-module.exports = function () {
+module.exports = function (program) {
+	
 	var client  = mqtt.connect('mqtt://localhost:1883')
 //	var client  = mqtt.connect('mqtt://test.mosquitto.org')
-	 
+	
+	var updateHandler = new UpdateHandler(program)
+	var createHandler = new CreateHandler(program)
+	var deleteHandler = new DeleteHandler(program)
+	
 	client.on('connect', function () {
 		
-		client.subscribe('solid', function (err) {
-			
+		client.subscribe('solid/+/create', function (err) {
 			if (!err) {
-				console.log('Successfully subscribed to topic "solid"')
-				client.publish('solid', 'MQTT says: Hello Sebastian!')
+				console.log('Successfully subscribed to topic "solid/+/create"')
 			} else {
 				console.log(err)
 			}
@@ -26,9 +32,64 @@ module.exports = function () {
 	
 	client.on('message', function (topic, message) {
 			// message is Buffer
-			console.log(message.toString())
+			//console.log('\nMQTT:\nOn topic: ' + topic + '\nRecieved message: ' + message.toString())
 
 			//TODO: add handlers for topics
+			let topicParts = topic.split('/')
+			
+			// topic = solid/<resID>/[create|delete]
+			if (topicParts.length == 3){
+				
+				if (topicParts[topicParts.length - 1] == 'create'){
+					console.log('MQTT CREATE in ' + topic)
+					createHandler.handle(topic, message)
+					client.subscribe('solid/' + topicParts[1], function (err) {
+						if (!err) {
+							console.log('Successfully subscribed to topic "solid/' + topicParts[1] + '"')
+						} else {
+							console.log(err)
+						}
+						
+					})
+					client.subscribe('solid/' + topicParts[1] + '/delete', function (err) {
+						if (!err) {
+							console.log('Successfully subscribed to topic "solid/' + topicParts[1] + '/delete"')
+						} else {
+							console.log(err)
+						}
+						
+					})
+				}
+				
+				if (topicParts[topicParts.length - 1] == 'delete'){
+					console.log('MQTT DELETE in ' + topic)
+					deleteHandler.handle(topic, message)
+					client.unsubscribe('solid/' + topicParts[1], function (err) {
+						if (!err) {
+							console.log('Successfully unsubscribed from topic "solid/' + topicParts[1] + '"')
+						} else {
+							console.log(err)
+						}
+						
+					})
+					client.unsubscribe('solid/' + topicParts[1] + '/delete', function (err) {
+						if (!err) {
+							console.log('Successfully unsubscribed from topic "solid/' + topicParts[1] + '/delete"')
+						} else {
+							console.log(err)
+						}
+						
+					})
+				}
+				
+			} else {
+				// topic = solid/<resID>
+				if (topicParts.length == 2){
+					console.log('MQTT UPDATE for ' + topic)
+					updateHandler.handle(topic, message)
+				}
+			}
+			
 	})
 	
 }

--- a/lib/iot/mqtt/CreateHandler.js
+++ b/lib/iot/mqtt/CreateHandler.js
@@ -1,0 +1,37 @@
+/*
+*   <#CreateHandler> 
+*       <http://www.w3.org/2000/01/rdf-schema#comment> "The MQTT handler for resource creation."@en ;
+*       <http://schema.org/author> https://sebatianrbader.inrupt.net/profile/card#me> ;
+*   .
+*/
+
+const debugMqtt = require('debug')('solid-iot:mqtt')
+intoStream = require('into-stream')
+require('../IotUtils')
+
+
+CreateHandler = function(program) {
+
+    this.handle = async function(topic, message) {
+        
+		debugMqtt('topic: ' + topic)
+		
+		let topicParts = topic.split('/')
+		let resourceID = '/' + topicParts[1]
+        
+        var iotUtils = new IotUtils()
+		var ldp = iotUtils.getLDP(program)
+		let contentType = "text/turtle"
+		
+		try {
+		  await ldp.put(resourceID, intoStream(message), contentType)
+		  debugMqtt('Succeded creating the resource ' + resourceID + ' with content:\n' + message)
+		} catch (err) {
+		  debugMqtt('Error creating the file:' + err.message)
+		  err.message = 'Can\'t write file: ' + err.message
+          return
+		}
+        
+    }
+
+}

--- a/lib/iot/mqtt/DeleteHandler.js
+++ b/lib/iot/mqtt/DeleteHandler.js
@@ -1,0 +1,40 @@
+/*
+*   <#DeleteHandler> 
+*       <http://www.w3.org/2000/01/rdf-schema#comment> "The MQTT handler for DELETE topics"@en ;
+*       <http://schema.org/author> https://sebatianrbader.inrupt.net/profile/card#me> ;
+*   .
+*/
+
+const debugMqtt = require('debug')('solid-iot:mqtt')
+require('../IotUtils')
+
+
+DeleteHandler = function(program) {
+
+    this.handle = async function(topic, message) {
+        
+		debugMqtt(topic)
+        
+        var iotUtils = new IotUtils()
+		var ldp = iotUtils.getLDP(program)
+		
+		let topicParts = topic.split('/')
+		let topicUrl = '/' + topicParts.slice(1, topicParts.length - 1).join('/')
+		debugMqtt(topicUrl)
+		
+		try {
+		  await ldp.delete(topicUrl)
+		  debugMqtt('DELETE -- Ok.\n' + topicUrl + ' successfully deleted.')
+		} catch (err) {
+			if (err.status === 404) {
+                debugMqtt('MQTT DELETE -- Error: Can\'t find ' + topicUrl + '!')
+                return
+            } else {
+                debugMqtt('MQTT ' + topicParts[topicParts.length - 1].toUpperCase() + ' -- Error: ' + err.status + ' ' + err.message)
+                return
+            }
+		}
+        
+    }
+
+}

--- a/lib/iot/mqtt/UpdateHandler.js
+++ b/lib/iot/mqtt/UpdateHandler.js
@@ -1,0 +1,58 @@
+/*
+*   <#UpdateHandler> 
+*       <http://www.w3.org/2000/01/rdf-schema#comment> "The MQTT handler for Updates via PUT requests"@en ;
+*       <http://schema.org/author> https://sebatianrbader.inrupt.net/profile/card#me> ;
+*   .
+*/
+
+const debugMqtt = require('debug')('solid-iot:mqtt')
+intoStream = require('into-stream')
+require('../IotUtils')
+
+
+UpdateHandler = function(program) {
+
+    this.handle = async function(topic, message) {
+        
+		debugMqtt('topic: ' + topic)
+		
+		let topicParts = topic.split('/')
+		let resourceID = '/' + topicParts[1]
+        
+        var iotUtils = new IotUtils()
+		var ldp = iotUtils.getLDP(program)
+		let contentType = "text/turtle"
+		
+		try {
+            resource = await ldp.readResource(resourceID).then(
+				async function(resource){
+					try{
+						await ldp.put(resourceID, intoStream(resource + '\n' + message), contentType)
+						debugMqtt('Succeded updating the resource ' + resourceID)
+						debugMqtt(resource + '\n' + message)
+					} catch (err) {
+						debugMqtt('Error updating the file:' + err.message)
+						err.message = 'Can\'t write file: ' + err.message
+						return
+					}
+				}
+				  
+			)
+        } catch (err) {
+            if (err.status === 404) {
+                debugMqtt('LDP returns 404')
+                return 'MQTT ' + topicParts[topicParts.length - 1].toUpperCase() + ' -- Error: ' + err.status + ' ' + err.message
+            } else {
+                debugMqtt('MQTT ' + topicParts[topicParts.length - 1].toUpperCase() + ' -- Error: ' + err.status + ' ' + err.message)
+                return
+            }
+        }
+
+        
+		
+		
+			
+    }
+	
+
+}


### PR DESCRIPTION
- `Server`: subscribe to `solid/+/create` -> listens to new file creations.
- `Client`: can publish a new resource with topic `solid/<resID>/create`.
- `Server`: creates resource and subscribes to `solid/<resID>` and `solid/<resID>/delete`.
- `Client`: can publish new updates to `solid/<resID>`.
- `Server`: gets notified on an update. Reads the current state of the resource and appends the new update.
- `Client`: can delete resource by publishing to `solid/<resID>/delete`.
- `Server`: deletes the resource and unsubscribes from  `solid/<resID>` and `solid/<resID>/delete`.